### PR TITLE
fix: enforce int type for --margin argument to prevent TypeError

### DIFF
--- a/bin/test.py
+++ b/bin/test.py
@@ -707,7 +707,7 @@ def main():
         "--profile", action="store_true", help="Print processing time information"
     )
     parser.add_argument(
-        "--margin", default=30, help="Margin for evaluation and rendering"
+        "--margin", default=30, type=int, help="Margin for evaluation and rendering"
     )
     parser.add_argument(
         "--disable_metrics", action="store_true", help="Disable metrics computation"


### PR DESCRIPTION
Hello, first of all, thank you for your work, this is a really cool project with very good features! 

This PR fixes a small bug with the command line argument parser to save others time searching for its origin. 

**Full command used to generate the error:**
```bash
TORCH_NUM_THREADS=4 PYTHONOPTIMIZE=TRUE PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True python tamrfsits/bin/test.py \
--ts ${PWD}/dataset/test/ \
--output ${PWD}/gap_filling/tamrfsits \
--checkpoint ${PWD}/model/tamrfsits_pretrained_2015974.ckpt \
--config ${PWD}/model/hydra_config/ \
--algorithm TAMRFSITS \
--strategy FORECAST \
--width 1650 \
--subtile_width 165 \
--margin 10 \
--forecast_doy_start 327 \
--show_subtile_progress \
--device cpu \
--write_images \
--generate_animation
```

**Error encountered:**

```python
  File ".../src/tamrfsits/validation/workflow.py", line 451, in <listcomp>
    *compute_lr_metrics(
     ^^^^^^^^^^^^^^^^^^^
  File ".../src/tamrfsits/validation/workflow.py", line 265, in compute_lr_metrics
    lr_ref_mask = derive_reference_mask(
                  ^^^^^^^^^^^^^^^^^^^^^^
  File ".../src/tamrfsits/validation/metrics.py", line 32, in derive_reference_mask
    mask[:, :, :, -spatial_margin:, :] = False
                  ^^^^^^^^^^^^^^^
TypeError: bad operand type for unary -: 'str'
```
**Solution:**
The `--margin` argument was missing a type declaration, which caused it to be read as a string when provided via the CLI. This resulted in a `TypeError` in `derive_reference_mask` when computing metrics (other parts of the code are also affected). Adding `type=int` to `parser.add_argument` resolves the issue.

I verified the fix by running the inference script again on my local machine.